### PR TITLE
Handle no such file error when creating untitled file

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -28,9 +28,11 @@ function sizeConvert(size) {
  * @param {import('vscode').TextDocument} doc
  */
 function updateSize(doc) {
-  const size = fs.statSync(doc.fileName).size;
-  const sizeMan = sizeConvert(size);
-  eventCollection.statusBar.text = sizeMan;
+  try {
+    const size = fs.statSync(doc.fileName).size;
+    const sizeMan = sizeConvert(size);
+    eventCollection.statusBar.text = sizeMan;
+  } catch {}
 }
 
 function activate() {


### PR DESCRIPTION
When creating an untitled file, the extension showed no such file error.

Added try-catch block to avoid extension throw error when requesting the file statistics fail.

![image_2022_11_29T03_26_24_180Z](https://user-images.githubusercontent.com/26683979/204539567-cc6608ad-4fa3-4c40-a85a-a93bf9172e9a.png)

![image_2022_11_29T03_26_30_205Z](https://user-images.githubusercontent.com/26683979/204539607-1ec6fb76-f0e6-498b-aae3-17ab3bb2df1d.png)
